### PR TITLE
exception handling, parameterized create_app()

### DIFF
--- a/makefile
+++ b/makefile
@@ -49,4 +49,4 @@ run:
 	sudo docker run -d -p 5000:5000 task-manager
 
 run_dev:
-	FLASK_APP=$(SRC_DIR) FLASK_ENV=development flask run
+	FLASK_APP=wsgi FLASK_ENV=development flask run

--- a/task_manager/__init__.py
+++ b/task_manager/__init__.py
@@ -13,10 +13,10 @@ ma = Marshmallow()
 apis = Api()
 
 
-def create_app():
+def create_app(config_name):
     """ Factory to initialize app """
-    app = Flask(__name__, instance_relative_config=False)
-    app.config.from_object('config.DevelopmentConfig')
+    app = Flask(__name__, instance_relative_config=True)
+    app.config.from_object(config_name)
 
     """ Initialize plugins """
     from .models.task import Task  # noqa: F401

--- a/task_manager/routes/tasks.py
+++ b/task_manager/routes/tasks.py
@@ -48,8 +48,9 @@ def model_post_create_task():
         return redirect('/tasks')
         #later this should return /tasks/new_task.id
 
-    except Exception:
-        return "Task could not be added :("
+    except Exception as e:
+        print(e)
+        return "Task could not be updated :("
 
 
 def model_fetch_task(task_id):
@@ -80,7 +81,8 @@ def model_post_update_task(task_id):
         return redirect('/tasks')
         #later this should return /tasks/new_task.id
 
-    except Exception:
+    except Exception as e:
+        print(e)
         return "Task could not be updated :("
 
 
@@ -92,5 +94,6 @@ def model_delete_task(task_id):
         db.session.commit()
         return redirect('/tasks')
 
-    except Exception:
+    except Exception as e:
+        print(e)
         return 'There was a problem deleting that task'

--- a/task_manager/tests/test_task.py
+++ b/task_manager/tests/test_task.py
@@ -8,7 +8,7 @@ from datetime import date
 
 class TestTask(unittest.TestCase):
 	def setUp(self):
-		self.app = create_app()
+		self.app = create_app('config.DevelopmentConfig')
 		self.app_context = self.app.app_context()
 		self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///test.sqlite3'
 		self.app_context.push()

--- a/task_manager/tests/test_user.py
+++ b/task_manager/tests/test_user.py
@@ -9,7 +9,7 @@ from task_manager.models.user import User
 
 class TestUser(unittest.TestCase):
     def setUp(self):
-        self.app = create_app()
+        self.app = create_app('config.DevelopmentConfig')
         self.app_context = self.app.app_context()
         self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///test.sqlite3'
         self.app_context.push()

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,6 +1,11 @@
+from os import environ, path
 from task_manager import create_app
+from dotenv import load_dotenv
 
-app = create_app()
+basedir = path.abspath(path.dirname(__file__))
+load_dotenv(path.join(basedir, '.env'))
+
+app = create_app(environ['FLASK_CONFIG'])
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0')


### PR DESCRIPTION
1. added exception printing in tasks.py for easier debugging

2. parameterized create_app() factory in init.py to allow config passing based on .env file. (e.g. set FLASK_CONFIG to "config.ProductionConfig" or leave default for development)

3. refactored tests that use create_app()